### PR TITLE
cli: Fix extraction of slicer version from CMakeLists.txt

### DIFF
--- a/slicer_apidocs_builder/__init__.py
+++ b/slicer_apidocs_builder/__init__.py
@@ -25,11 +25,13 @@ def extract_slicer_xy_version(slicer_src_dir):
                    for part in ["major", "minor"]}
     parts = {}
     with open(slicer_src_dir + "/CMakeLists.txt") as fp:
-        for line in fp.readlines(50):
+        for line in fp:
             for part, expression in expressions.items():
                 m = expression.match(line.strip())
                 if m is not None:
                     parts[part] = m.group(1)
+            if len(parts) == len(expressions):
+              break
     return "{major}.{minor}".format(**parts) if parts else None
 
 


### PR DESCRIPTION
This commit fixes the following error:

```
  Traceback (most recent call last):
    File "/usr/local/bin/slicer-apidocs-builder", line 8, in <module>
      sys.exit(main())
    File "/usr/local/lib/python3.9/site-packages/slicer_apidocs_builder/__init__.py", line 530, in main
      exit(cli())
    File "/usr/local/lib/python3.9/site-packages/slicer_apidocs_builder/__init__.py", line 482, in cli
      _apidocs_build_doxygen(
    File "/usr/local/lib/python3.9/site-packages/slicer_apidocs_builder/__init__.py", line 90, in _apidocs_build_doxygen
      assert version
  AssertionError
```