### PR TITLE
Use https instead of git protocol

### DIFF
--- a/slicer_apidocs_builder/__init__.py
+++ b/slicer_apidocs_builder/__init__.py
@@ -429,7 +429,7 @@ def cli():
         return 0
 
     # apidocs building parameters
-    slicer_repo_clone_url = "git://github.com/%s" % args.slicer_repo_name
+    slicer_repo_clone_url = "https://github.com/%s" % args.slicer_repo_name
 
     # Apidocs directories
     apidocs_src_dir = root_dir + "/" + "%s-src" % directory
@@ -441,7 +441,7 @@ def cli():
     publish_github_useremail = args.publish_github_useremail
     publish_github_repo_name = args.publish_github_repo_name
     publish_github_repo_branch = args.publish_github_repo_branch
-    publish_github_repo_url = "git://github.com/" + publish_github_repo_name
+    publish_github_repo_url = "https://github.com/" + publish_github_repo_name
     publish_github_token = args.publish_github_token
 
     # Skipping


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/

Originally observed issue in a failed API docs build of https://github.com/Slicer/Slicer/pull/6108
https://app.circleci.com/pipelines/github/Slicer/apidocs.slicer.org/2527/workflows/8f42930d-1ac5-47f3-a786-23872c237cac/jobs/6818
```
Copying /usr/local/lib/python3.9/site-packages/slicer_apidocs_builder/CMakeLists.txt into /tmp/jamesobutler-Slicer-qt6-prep-src

> git clone git://github.com/jamesobutler/Slicer --branch qt6-prep --depth 1 /tmp/jamesobutler-Slicer-qt6-prep

Cloning into '/tmp/jamesobutler-Slicer-qt6-prep'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Exit code: 128
```